### PR TITLE
Update function: check_cncli_send_tip(), within: healthcheck.sh

### DIFF
--- a/files/docker/node/addons/healthcheck.sh
+++ b/files/docker/node/addons/healthcheck.sh
@@ -100,7 +100,7 @@ check_cncli_send_tip() {
 
     # Check if the json success message exists in the captured log
     if echo "$pt_log_entry" | grep -q $json_success_status; then
-        echo -e "Healthy: Tip sent to Pooltool. (Current tip = $SECOND_TIP)."
+        echo "Healthy: Tip sent to Pooltool. (Current tip = $SECOND_TIP)."
         return 0  # Return 0 if the success message is found
     # Check if the json failure message exists in the captured log
     elif echo "$pt_log_entry" | grep -q $json_failure_status; then

--- a/files/docker/node/addons/healthcheck.sh
+++ b/files/docker/node/addons/healthcheck.sh
@@ -70,7 +70,7 @@ check_cncli_db() {
 # Function to check if the tip is successfully being sent to Pooltool
 check_cncli_send_tip() {
     # Timeout in seconds for capturing the log entry
-    log_entry_timeout=60
+    log_entry_timeout=99
 
     # Get the process ID of cncli
     process_id=$(pgrep -of cncli) || {
@@ -78,11 +78,20 @@ check_cncli_send_tip() {
         return 1  # Return 1 if the process is not found
     }
 
+    # Get the current tip from the node
+    FIRST_TIP=$($CCLI query tip --testnet-magic ${NWMAGIC} | jq .block)
     # Capture the next output from cncli that is related to Pooltool
     pt_log_entry=$(timeout $log_entry_timeout cat /proc/$process_id/fd/1 | grep --line-buffered "Pooltool" | head -n 1)
+    # Get the current tip again
+    SECOND_TIP=$($CCLI query tip --testnet-magic ${NWMAGIC} | jq .block)
     if [ -z "$pt_log_entry" ]; then
-        echo "Unable to capture cncli output within $log_entry_timeout seconds."
-        return 1  # Return 1 if the output capture fails
+        if [[ "$FIRST_TIP" -eq "$SECOND_TIP" ]]; then
+            echo "Unable to capture cncli output within $log_entry_timeout seconds, but node has not moved tip. (Current tip = $SECOND_TIP)."
+            return 0
+        else
+            echo "Unable to capture cncli output within $log_entry_timeout seconds. (Current tip = $SECOND_TIP)."
+            return 1  # Return 1 if the output capture fails
+        fi
     fi
 
     # Define the json success message to check for
@@ -91,16 +100,17 @@ check_cncli_send_tip() {
 
     # Check if the json success message exists in the captured log
     if echo "$pt_log_entry" | grep -q $json_success_status; then
-        echo "Healthy: Tip is being sent to Pooltool."
+        echo -e "Healthy: Tip sent to Pooltool. (Current tip = $SECOND_TIP)."
         return 0  # Return 0 if the success message is found
     # Check if the json failure message exists in the captured log
     elif echo "$pt_log_entry" | grep -q $json_failure_status; then
         failure_message=$(echo "$pt_log_entry" | grep -oP '"message":"\K[^"]+')
-        echo "Failed to send tip. $failure_message"
+        echo "Failed to send tip. (Current tip = $SECOND_TIP). $failure_message"
         return 1  # Return 1 if the failure message is found
     # If the log entry does not contain a json success or failure message
     else
-        echo "Failed to send tip. $pt_log_entry"
+        # Log the raw output if no json message is found
+        echo "Failed to send tip. (Current tip = $SECOND_TIP). $pt_log_entry"
         return 1  # Return 1 if it fails for any other reason
     fi
 }


### PR DESCRIPTION
- Added checks for the tip progressing to reduce false positives when the timeout is reached but the tip hasn't moved.

- Increased the log_entry_timeout to 99, to be just within the container HEATHCHECK timout of 100.

- Improved log output to include current tip, providing more info to the operator.