### PR TITLE
Add sendslots healthcheck

### DIFF
--- a/files/docker/node/addons/healthcheck.sh
+++ b/files/docker/node/addons/healthcheck.sh
@@ -139,6 +139,7 @@ check_cncli_sendslots() {
         | jq -r .status
 
         if [[ "$cncli_status" == "ok" ]]; then
+            # Will later add checks for required variables. e.g... $POOLTOOL_API_KEY, $CARDANO_POOL_TICKER
             echo "cncli status is 'ok', indicating readiness to send slots to PoolTool"
             return 0
         else

--- a/files/docker/node/addons/healthcheck.sh
+++ b/files/docker/node/addons/healthcheck.sh
@@ -116,6 +116,41 @@ check_cncli_sendtip() {
 }
 
 
+# Function to check cncli sendslots
+check_cncli_sendslots() {
+    CNCLI=$(which cncli)
+
+    # Get the status of cncli
+    cncli_status=$CNCLI status \
+        --byron-genesis /opt/cardano/cnode/files/byron-genesis.json \
+        --shelley-genesis /opt/cardano/cnode/files/shelley-genesis.json \
+        --db /opt/cardano/cnode/guild-db/cncli/cncli.db \
+        | jq -r .status
+
+    # Temp file which stores the status of the last cncli_ptsendslots command
+    tmp_status_file="/dev/shm/cncli_ptsendslots.status"
+    # If the temp file exists, check the status of the last cncli_ptsendslots command
+    if [[ -f "$tmp_status_file" ]]; then
+        if grep -q "successfully" "$tmp_status_file"; then
+            echo "The last attempt to send slots to Pooltool succeeded. Output: $(cat $tmp_status_file)"
+            return 0
+        else
+            echo "The last attempt to send slots to Pooltool failed. Output: $(cat $tmp_status_file)"
+            return 1
+        fi
+    # If the temp file does not exist, check the readiness of cncli to send slots
+    else
+        if [[ "$cncli_status" == "ok" ]]; then
+            echo "cncli status is 'ok', indicating readiness to send slots to PoolTool"
+            return 0
+        else
+            echo "Error: cncli status is not 'ok', indicating un-readiness to send slots to PoolTool"
+            return 1
+        fi
+    fi
+}
+
+
 check_db_sync() {
     # Check if the DB is in sync
     [[ -z "${PGPASSFILE}" ]] && PGPASSFILE="${CNODE_HOME}/priv/.pgpass"

--- a/files/docker/node/addons/healthcheck.sh
+++ b/files/docker/node/addons/healthcheck.sh
@@ -118,15 +118,6 @@ check_cncli_sendtip() {
 
 # Function to check cncli sendslots
 check_cncli_sendslots() {
-    CNCLI=$(which cncli)
-
-    # Get the status of cncli
-    cncli_status=$CNCLI status \
-        --byron-genesis /opt/cardano/cnode/files/byron-genesis.json \
-        --shelley-genesis /opt/cardano/cnode/files/shelley-genesis.json \
-        --db /opt/cardano/cnode/guild-db/cncli/cncli.db \
-        | jq -r .status
-
     # Temp file which stores the status of the last cncli_ptsendslots command
     tmp_status_file="/dev/shm/cncli_ptsendslots.status"
     # If the temp file exists, check the status of the last cncli_ptsendslots command
@@ -140,6 +131,13 @@ check_cncli_sendslots() {
         fi
     # If the temp file does not exist, check the readiness of cncli to send slots
     else
+        CNCLI=$(which cncli)
+        cncli_status=$CNCLI status \
+        --byron-genesis /opt/cardano/cnode/files/byron-genesis.json \
+        --shelley-genesis /opt/cardano/cnode/files/shelley-genesis.json \
+        --db /opt/cardano/cnode/guild-db/cncli/cncli.db \
+        | jq -r .status
+
         if [[ "$cncli_status" == "ok" ]]; then
             echo "cncli status is 'ok', indicating readiness to send slots to PoolTool"
             return 0

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -793,7 +793,8 @@ cncliPTsendslots() {
     leaderlog_cnt=$(sqlite3 "${CNCLI_DB}" "SELECT COUNT(*) FROM slots WHERE epoch=${epochnum} and pool_id='${POOL_ID}';")
     [[ ${leaderlog_cnt} -eq 0 ]] && echo "ERROR: no leaderlogs for epoch ${epochnum} and pool id '${POOL_ID}' found in cncli DB" && continue
     cncli_ptsendslots=$(${CNCLI} sendslots --config "${pt_config}" --db "${CNCLI_DB}" --byron-genesis "${BYRON_GENESIS_JSON}" --shelley-genesis "${GENESIS_JSON}")
-    echo -e "${cncli_ptsendslots}"
+    tmp_status_file="/dev/shm/cncli_ptsendslots.status" # store status in a ram-file for healthcheck.sh to read at a later time
+    echo -e "${cncli_ptsendslots}" | tee "${tmp_status_file}"
     if [[ $(jq -r '.status //empty' <<< "${cncli_ptsendslots}" 2>/dev/null) = "error" ]]; then continue; fi
     echo "Slots for epoch ${epochnum} successfully sent to PoolTool for pool id '${POOL_ID}' !"
     sendslots_epoch=${epochnum}


### PR DESCRIPTION
Added a function to check the last result of ptsendslots to the healthcheck script.

ptsendslots only creates stdout output once every 5 days (at the start of each epoch) so a healthcheck script which runs every few minutes won't be able to get any useful info from the sendtip file descriptor stream. My thought was to solve this by storing the result in a temp-ram file: ```tmp_status_file="/dev/shm/cncli_ptsendslots.status"```

This is a rough draft to determine if this might be a valid solution and to ask for your input if you have any better ideas?

If we're proceeding with it, I would add further checks for required variables. (e.g... $POOLTOOL_API_KEY, $CARDANO_POOL_TICKER)

Here's what example output looks like:
![sucess](https://github.com/user-attachments/assets/4d1da7b7-8d03-4ed7-882a-33cda439da51)
Side note. API keys shouldn't be leaked to logs for security reasons.


Thanks, Adam